### PR TITLE
Version 2.3 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Usage is the same and should work out of the box for smokeping.
 It comes with various improvements like language agonstic functionality, better error detection, debug, and removed tcptraceroute dependancy.
 
 So far, tests have been done with:
-- CentOS 7: v2.0-2.3 tested (with traceroute 2.0.22)
-- CentOS 8: v2.3 tested (with traceroute 2.1.0)
-- FreeBSD 11.2: v2.0-2.3 tested (with traceroute 1.4a12)
+- CentOS 7: v2.0-2.3 tested (with traceroute 2.0.22 and bash 4.2.46(2)-release)
+- CentOS 8: v2.3 tested (with traceroute 2.1.0 and bash 4.4.19(1)-release)
+- FreeBSD 11.2: v2.0-2.3 tested (with traceroute 1.4a12 and tcsh 6.20.00)
 Also, smokeping 2.7.2 and 2.7.3 have been tested.
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
-# tcpping
+# tcpping v2.x
 
 ## fork of elder tcpping v1.8 script running with newer traceroute binary
 
-This script is a fork of Richard Van de Berg's tcpping script, supporiting newer traceroute binaries.
+This script is a fork of Richard Van de Berg's tcpping script, original version found [here](https://github.com/deajan/tcpping/tree/original-1.8), supporting newer traceroute binaries.
 Usage is the same and should work out of the box for smokeping.
 
 It comes with various improvements like language agonstic functionality, better error detection, debug, and removed tcptraceroute dependancy.
 
-This is still a basic work and has only been tested on CentOS 7, FreeBSD 11 and smokeping 2.7.2 so far.
-On CentOS 7, traceroute 2.0.22  has been tested.
-On FreeBSD, traceroute 1.4a12 has been tested.
+So far, tests have been done with:
+- CentOS 7: v2.0-2.3 tested (with traceroute 2.0.22)
+- CentOS 8: v2.3 tested (with traceroute 2.1.0)
+- FreeBSD 11.2: v2.0-2.3 tested (with traceroute 1.4a12)
+Also, smokeping 2.7.2 and 2.7.3 have been tested.
 
 ## Installation
 

--- a/tcpping
+++ b/tcpping
@@ -6,7 +6,7 @@
 #
 # uses recent versions of traceroute supporting TCP sessions
 #
-# (c) 2002-2018 Richard van den Berg <richard@vdberg.org> under the GPL
+# (c) 2002-2019 Richard van den Berg <richard@vdberg.org> under the GPL
 #               http://www.gnu.org/copyleft/gpl.html
 #               Orsiris de Jong <ozy@netpower.fr>
 # 
@@ -150,7 +150,7 @@ checkEnvironment() {
 		echo >&2 "traceroute binary not found. Please install it first"
 		exit 1
 	fi
-	
+
 	if ! type awk > /dev/null; then
 		echo >&2 "awk binary not found. Please install it first"
 		exit 2
@@ -269,7 +269,7 @@ _testSite() {
 	else
 		echo "${traceRoute}" | sed -e "s/^.*\*.*$/seq $myseq: no response (timeout)/" -e "s/^$ttl /seq $myseq: tcp response from/"
 	fi
-	
+
 	if [ "`echo "${traceRoute}" | awk '{print $1}'`" = "*" ]; then
                 return 1
         else
@@ -299,7 +299,7 @@ while getopts Zdhzq:w:cr:nNFSAEi:f:l:m:p:s:x:CM:o opt ; do
 			icmp) ;;
 			tcp) ;;
 			udp) ;;
-			*) 
+			*)
 			echo >&2 "Unsupported method. Falling back to TCP"
 			METHOD=tcp
 			;;

--- a/tcpping
+++ b/tcpping
@@ -38,6 +38,7 @@
 #                 fixed bogus -w parameter 
 # 2019/09/25 v2.3 allow -w parameter to take floats
 #                 added -o parameter, which outputs statistics similar to ping
+#                 Simpify main loop
 
 ver="v2.3"
 format="%Y%m%d%H%M%S"
@@ -367,58 +368,35 @@ err=$?
 pingCount=0
 pingFailCount=0
 if [ "$x" = "" ]; then
-	while [ true ] ; do
-		result=""
-		_testSite "${host}" "${port}" ${seq} ${topt} &
-		pid=$!
-
-		if [ "${C}" = "yes" ]; then
-			wait $pid
-			result=$?
-		fi
-		seq=`expr $seq + 1`
-		if [ $seq -gt 0 ]; then
-			_DEBUG=false
-		fi
-		sleep ${repeatWaitTime}
-		if [ "$result" == "" ]; then
-			wait $pid > /dev/null 2>&1
-			result=$?
-		fi
-		
-		pingCount=$((pingCount+1))
-		if [ $result -ne 0 ]; then
-			pingFailCount=$((pingFailCount+1))
-		fi
-	done
-else
-	while [ "$x" -gt 0 ] ; do
-		result=""
-		_testSite "${host}" "${port}" ${seq} ${topt} &
-		pid=$!
-
-		if [ "${C}" = "yes" ]; then
-			wait $pid
-			result=$?
-		fi
-		seq=`expr $seq + 1`
-		if [ $seq -gt 0 ]; then
-			_DEBUG=false
-		fi
-		x=`expr $x - 1`
-		if [ "$x" -gt 0 ]; then
-			sleep ${repeatWaitTime}
-		fi
-				if [ "$result" == "" ]; then
-			wait $pid > /dev/null 2>&1
-			result=$?
-		fi
-		
-		pingCount=$((pingCount+1))
-		if [ $result -ne 0 ]; then
-			pingFailCount=$((pingFailCount+1))
-		fi
-	done
+        x=-1
 fi
+
+while [ "$x" -gt 0 ] || [ "$x" -le -1 ]; do
+	result=""
+	_testSite "${host}" "${port}" ${seq} ${topt} &
+	pid=$!
+
+	if [ "${C}" = "yes" ]; then
+		wait $pid
+		result=$?
+	fi
+	seq=`expr $seq + 1`
+	if [ $seq -gt 0 ]; then
+		_DEBUG=false
+	fi
+	x=`expr $x - 1`
+	if [ "$x" -gt 0 ] || [ "$x" -le -1 ]; then
+		sleep ${repeatWaitTime}
+	fi
+	if [ "$result" == "" ]; then
+		wait $pid > /dev/null 2>&1
+		result=$?
+	fi
+
+	pingCount=$((pingCount+1))
+	if [ $result -ne 0 ]; then
+		pingFailCount=$((pingFailCount+1))
+	fi
+done
 
 exit

--- a/tcpping
+++ b/tcpping
@@ -9,7 +9,7 @@
 # (c) 2002-2019 Richard van den Berg <richard@vdberg.org> under the GPL
 #               http://www.gnu.org/copyleft/gpl.html
 #               Orsiris de Jong <ozy@netpower.fr>
-# 
+#
 # 2002/12/20 v1.0 initial version
 # 2003/01/25 v1.1 added -c and -r options
 #                 now accepting all other tcptraceroute options
@@ -35,12 +35,12 @@
 #                 added -Z parameter for sudo
 #                 added -M parameter for protocol
 #                 removed bc dependancy
-#                 fixed bogus -w parameter 
-# 2019/09/25 v2.3 allow -w parameter to take floats
+#                 fixed bogus -w parameter
+# 2019/09/25 v2.3 allow -w parameter to take floats under linux
+#                 meantime between checks is now lowered if -w parameter is less than 1 second on linux
 #                 added -o parameter, which outputs statistics similar to ping
 #                 Simpify main loop
 #                 fix ambiguous output redirect in csh for preflight check
-
 
 ver="v2.3"
 format="%Y%m%d%H%M%S"
@@ -381,9 +381,6 @@ while [ $pingCount -lt $x ] || [ $x -eq 0 ]; do
 	if [ $seq -gt 0 ]; then
 		_DEBUG=false
 	fi
-	if [ $pingCount -lt $x ] || [ $x -eq 0 ]; then
-		sleep ${repeatWaitTime}
-	fi
 	if [ "$result" = "" ]; then
 		wait $pid > /dev/null 2>&1
 		result=$?
@@ -392,6 +389,9 @@ while [ $pingCount -lt $x ] || [ $x -eq 0 ]; do
 	pingCount=`expr $pingCount + 1`
 	if [ $result -ne 0 ]; then
 		pingFailCount=`expr $pingFailCount + 1`
+	fi
+	if [ $pingCount -lt $x ] || [ $x -eq 0 ]; then
+		sleep ${repeatWaitTime}
 	fi
 done
 

--- a/tcpping
+++ b/tcpping
@@ -40,6 +40,8 @@
 #                 added -o parameter, which outputs statistics similar to ping
 #                 Simpify main loop
 
+# TODO            Simplify code, improve variable names, uniform `expr ` and $(( )) statements
+
 ver="v2.3"
 format="%Y%m%d%H%M%S"
 d="no"

--- a/tcpping
+++ b/tcpping
@@ -39,8 +39,8 @@
 # 2019/09/25 v2.3 allow -w parameter to take floats
 #                 added -o parameter, which outputs statistics similar to ping
 #                 Simpify main loop
+#                 fix ambiguous output redirect in csh for preflight check
 
-# TODO            Simplify code, improve variable names, uniform `expr ` and $(( )) statements
 
 ver="v2.3"
 format="%Y%m%d%H%M%S"
@@ -62,6 +62,7 @@ METHOD=tcp
 protoOptions="-T"
 proto=tcp
 summary="no"
+x=0
 
 # Make sure traceroute output is language agnostic
 export LANG=C
@@ -105,11 +106,11 @@ getLocalOS() {
 		if grep -i Microsoft /proc/sys/kernel/osrelease > /dev/null 2>&1; then
 			localOsVar="Microsoft"
 		else
-			localOsVar="$(uname -spior 2>&1)"
+			localOsVar="`uname -spior 2>&1`"
 			if [ $? != 0 ]; then
-				localOsVar="$(uname -v 2>&1)"
+				localOsVar="`uname -v 2>&1`"
 				if [ $? != 0 ]; then
-					localOsVar="$(uname)"
+					localOsVar="`uname`"
 				fi
 			fi
 		fi
@@ -148,9 +149,14 @@ getLocalOS() {
 }
 
 checkEnvironment() {
-	if ! type traceroute > /dev/null 2>&1 ; then
+	if ! type traceroute > /dev/null; then
 		echo >&2 "traceroute binary not found. Please install it first"
 		exit 1
+	fi
+	
+	if ! type awk > /dev/null; then
+		echo >&2 "awk binary not found. Please install it first"
+		exit 2
 	fi
 }
 
@@ -178,7 +184,7 @@ _checkSite() {
 
 	traceRoute=`$traceRouteCommand 2>&1`
 	if [ $? -ne 0 ]; then
-		if [ "$(id -u)" -ne 0 ]; then
+		if [ "`id -u`" -ne 0 ]; then
 			echo >&2 "Unable to run '$traceRouteCommand' command. Please try run $0 with -Z parameter or 'sudo $0'"
 			return 20
 		else
@@ -320,12 +326,8 @@ if [ "${summary}" == "yes" ]; then
 	trap _quit SIGQUIT EXIT
 fi
 
-# Check if timeToWait is float, if yes, use maybe less portable awk version
-if [ "${timeToWait}" != "${timeToWait/./}" ]; then
-        max=$(awk 'BEGIN{printf "%.2f\n", ('${timeToWait}'*1000)}')
-else
-        max=$((${timeToWait} * 1000))
-fi
+# Use awk to multiply possible float in timeToWait
+max=`awk 'BEGIN{printf "%.2f\n", ('${timeToWait}'*1000)}'`
 
 if [ `date +%s` != "%s" ]; then
 	format="%s"
@@ -333,7 +335,6 @@ fi
 
 getLocalOS
 
-#WIP check here
 if [ "$LOCAL_OS" = "BSD" ] || [ "$LOCAL_OS" = "MacOSX" ]; then
 	METHOD_PARAMETER="-P"
 else
@@ -369,11 +370,8 @@ err=$?
 
 pingCount=0
 pingFailCount=0
-if [ "$x" = "" ]; then
-        x=-1
-fi
 
-while [ "$x" -gt 0 ] || [ "$x" -le -1 ]; do
+while [ $pingCount -lt $x ] || [ $x -eq 0 ]; do
 	result=""
 	_testSite "${host}" "${port}" ${seq} ${topt} &
 	pid=$!
@@ -386,8 +384,7 @@ while [ "$x" -gt 0 ] || [ "$x" -le -1 ]; do
 	if [ $seq -gt 0 ]; then
 		_DEBUG=false
 	fi
-	x=`expr $x - 1`
-	if [ "$x" -gt 0 ] || [ "$x" -le -1 ]; then
+	if [ $pingCount -lt $x ] || [ $x -eq 0 ]; then
 		sleep ${repeatWaitTime}
 	fi
 	if [ "$result" == "" ]; then
@@ -395,9 +392,9 @@ while [ "$x" -gt 0 ] || [ "$x" -le -1 ]; do
 		result=$?
 	fi
 
-	pingCount=$((pingCount+1))
+	pingCount=`expr $pingCount + 1`
 	if [ $result -ne 0 ]; then
-		pingFailCount=$((pingFailCount+1))
+		pingFailCount=`expr $pingFailCount + 1`
 	fi
 done
 

--- a/tcpping
+++ b/tcpping
@@ -270,11 +270,8 @@ _testSite() {
 		echo "${traceRoute}" | sed -e "s/^.*\*.*$/seq $myseq: no response (timeout)/" -e "s/^$ttl /seq $myseq: tcp response from/"
 	fi
 
-	if [ "`echo "${traceRoute}" | awk '{print $1}'`" = "*" ]; then
-                return 1
-        else
-                return 0
-        fi
+	echo "${traceRoute}" | awk '($1 == "*" || $2 == "*"){ exit 1 }'
+	return $?
 }
 
 _quit() {

--- a/tcpping
+++ b/tcpping
@@ -320,7 +320,7 @@ if [ "x$1" = "x" ]; then
 fi
 
 if [ "${summary}" = "yes" ]; then
-	trap _quit SIGQUIT EXIT
+	trap _quit SIGQUIT INT
 fi
 
 # Use awk to multiply possible float in timeToWait
@@ -399,5 +399,7 @@ while [ $pingCount -lt $x ] || [ $x -eq 0 ]; do
 		sleep ${repeatWaitTime}
 	fi
 done
-
+if [ "$summary" = "yes" ]; then
+	_quit
+fi
 exit

--- a/tcpping
+++ b/tcpping
@@ -36,8 +36,10 @@
 #                 added -M parameter for protocol
 #                 removed bc dependancy
 #                 fixed bogus -w parameter 
+# 2019/09/25 v2.3 allow -w parameter to take floats
+#                 added -o parameter, which outputs statistics similar to ping
 
-ver="v2.2"
+ver="v2.3"
 format="%Y%m%d%H%M%S"
 d="no"
 c="no"
@@ -56,6 +58,7 @@ METHOD=tcp
 #WIP remove
 protoOptions="-T"
 proto=tcp
+summary="no"
 
 # Make sure traceroute output is language agnostic
 export LANG=C
@@ -79,6 +82,7 @@ usage () {
 	echo "        --sport       define source port, see traceroute man"
 	echo "        -z            show what command is actually sent to traceroute (debug)"
 	echo "        -Z            run traceroute with sudo"
+	echo "        -o            Output ping like statistics"
 	echo
 	echo "Default port is 80"
 	echo "See also: man traceroute"
@@ -259,6 +263,18 @@ _testSite() {
 	else
 		echo "${traceRoute}" | sed -e "s/^.*\*.*$/seq $myseq: no response (timeout)/" -e "s/^$ttl /seq $myseq: tcp response from/"
 	fi
+	
+	if [ "`echo "${traceRoute}" | awk '{print $1}'`" == "*" ]; then
+                return 1
+        else
+                return 0
+        fi
+}
+
+_quit() {
+        echo ""
+        echo "${pingCount} packets transmitted, ${failureCount} received."
+        exit
 }
 
 checkEnvironment
@@ -284,6 +300,7 @@ while getopts Zdhzq:w:cr:nNFSAEi:f:l:m:p:s:x:CM: opt ; do
 		esac ;;
 		Z) SUDO_COMMAND=sudo ;;
 		z) _DEBUG=true ;;
+		o) summary="yes" ;;
 		?) usage; exit ;;
 	esac
 done
@@ -296,7 +313,14 @@ if [ "x$1" = "x" ]; then
 	exit
 fi
 
-max=$((${timeToWait} * 1000))
+trap _quit SIGQUIT
+
+# Check if timeToWait is float, if yes, use maybe less portable awk version
+if [ "${timeToWait}" != "${timeToWait/./}" ]; then
+        max=$(awk 'BEGIN{printf "%.2f\n", ('${timeToWait}'*1000)}')
+else
+        max=$((${timeToWait} * 1000))
+fi
 
 if [ `date +%s` != "%s" ]; then
 	format="%s"
@@ -338,27 +362,42 @@ err=$?
 
 [ ${err} -gt 0 ] && exit ${err}
 
+pingCount=0
+pingFailCount=0
 if [ "$x" = "" ]; then
 	while [ true ] ; do
+		result=""
 		_testSite "${host}" "${port}" ${seq} ${topt} &
 		pid=$!
 
 		if [ "${C}" = "yes" ]; then
 			wait $pid
+			result=$?
 		fi
 		seq=`expr $seq + 1`
 		if [ $seq -gt 0 ]; then
 			_DEBUG=false
 		fi
 		sleep ${repeatWaitTime}
+		if [ "$result" == "" ]; then
+			wait $pid > /dev/null 2>&1
+			result=$?
+		fi
+		
+		pingCount=$((pingCount+1))
+		if [ $result -ne 0 ]; then
+			pingFailCount=$((pingFailCount+1))
+		fi
 	done
 else
 	while [ "$x" -gt 0 ] ; do
+		result=""
 		_testSite "${host}" "${port}" ${seq} ${topt} &
 		pid=$!
 
 		if [ "${C}" = "yes" ]; then
 			wait $pid
+			result=$?
 		fi
 		seq=`expr $seq + 1`
 		if [ $seq -gt 0 ]; then
@@ -367,6 +406,15 @@ else
 		x=`expr $x - 1`
 		if [ "$x" -gt 0 ]; then
 			sleep ${repeatWaitTime}
+		fi
+				if [ "$result" == "" ]; then
+			wait $pid > /dev/null 2>&1
+			result=$?
+		fi
+		
+		pingCount=$((pingCount+1))
+		if [ $result -ne 0 ]; then
+			pingFailCount=$((pingFailCount+1))
 		fi
 	done
 fi

--- a/tcpping
+++ b/tcpping
@@ -276,7 +276,7 @@ _testSite() {
 
 _quit() {
         echo ""
-        echo "${pingCount} packets transmitted, ${pingFailCount} received."
+        echo "${pingCount} packets transmitted, `expr ${pingCount} - ${pingFailCount}` received."
         exit
 }
 

--- a/tcpping
+++ b/tcpping
@@ -58,9 +58,6 @@ SUDO_COMMAND=""
 _DEBUG=false
 LOCAL_OS=
 METHOD=tcp
-#WIP remove
-protoOptions="-T"
-proto=tcp
 summary="no"
 x=0
 
@@ -251,7 +248,7 @@ _testSite() {
 		if [ "x${rtt}" != "x" -a "x${not}" = "x" ]; then
 			echo "$myseq $nows $rtt $host"
 		else
-			echo "$myseq $nows $max $host"
+			echo "$myseq $nows $maxRtt $host"
 		fi
 	elif [ "${C}" = "yes" ]; then
 		if [ "$myseq" = "0" ]; then
@@ -327,7 +324,7 @@ if [ "${summary}" = "yes" ]; then
 fi
 
 # Use awk to multiply possible float in timeToWait
-max=`awk 'BEGIN{printf "%.2f\n", ('${timeToWait}'*1000)}'`
+maxRtt=`awk 'BEGIN{printf "%.2f\n", ('${timeToWait}'*1000)}'`
 
 if [ `date +%s` != "%s" ]; then
 	format="%s"

--- a/tcpping
+++ b/tcpping
@@ -73,7 +73,7 @@ usage () {
 	echo "        -d            print timestamp before every result"
 	echo "        -c            print a columned result line"
 	echo "        -C            print in the same format as fping's -C option"
-	echo "        -w            wait time in seconds (defaults to 3)"
+	echo "        -w            wait time in seconds (defaults to 3). Linux supports float values, ie '.2'"
 	echo "        -r            repeat every n seconds (defaults to 1)"
 	echo "        -x            repeat n times (defaults to unlimited)"
 	echo "        -f            first ttl (defaults to 255), see traceroute man"

--- a/tcpping
+++ b/tcpping
@@ -365,6 +365,11 @@ err=$?
 
 [ ${err} -gt 0 ] && exit ${err}
 
+# if timeToWait is lower than repeatWaitTime (1 sec), repeatWaitTime should be equal to timeToWait in order to speed up pings after timeout
+if ! awk 'BEGIN { exit "'$repeatWaitTime'">"'$timeToWait'" }'; then
+	repeatWaitTime=$timeToWait
+fi
+
 pingCount=0
 pingFailCount=0
 

--- a/tcpping
+++ b/tcpping
@@ -273,13 +273,13 @@ _testSite() {
 
 _quit() {
         echo ""
-        echo "${pingCount} packets transmitted, ${failureCount} received."
+        echo "${pingCount} packets transmitted, ${pingFailCount} received."
         exit
 }
 
 checkEnvironment
 
-while getopts Zdhzq:w:cr:nNFSAEi:f:l:m:p:s:x:CM: opt ; do
+while getopts Zdhzq:w:cr:nNFSAEi:f:l:m:p:s:x:CM:o opt ; do
 	case "$opt" in
 		d|c|C) eval $opt="yes" ;;
 		q|r|x) eval $opt="$OPTARG" ;;
@@ -313,7 +313,9 @@ if [ "x$1" = "x" ]; then
 	exit
 fi
 
-trap _quit SIGQUIT
+if [ "${summary}" == "yes" ]; then
+	trap _quit SIGQUIT EXIT
+fi
 
 # Check if timeToWait is float, if yes, use maybe less portable awk version
 if [ "${timeToWait}" != "${timeToWait/./}" ]; then

--- a/tcpping
+++ b/tcpping
@@ -273,7 +273,7 @@ _testSite() {
 		echo "${traceRoute}" | sed -e "s/^.*\*.*$/seq $myseq: no response (timeout)/" -e "s/^$ttl /seq $myseq: tcp response from/"
 	fi
 	
-	if [ "`echo "${traceRoute}" | awk '{print $1}'`" == "*" ]; then
+	if [ "`echo "${traceRoute}" | awk '{print $1}'`" = "*" ]; then
                 return 1
         else
                 return 0
@@ -322,7 +322,7 @@ if [ "x$1" = "x" ]; then
 	exit
 fi
 
-if [ "${summary}" == "yes" ]; then
+if [ "${summary}" = "yes" ]; then
 	trap _quit SIGQUIT EXIT
 fi
 
@@ -387,7 +387,7 @@ while [ $pingCount -lt $x ] || [ $x -eq 0 ]; do
 	if [ $pingCount -lt $x ] || [ $x -eq 0 ]; then
 		sleep ${repeatWaitTime}
 	fi
-	if [ "$result" == "" ]; then
+	if [ "$result" = "" ]; then
 		wait $pid > /dev/null 2>&1
 		result=$?
 	fi


### PR DESCRIPTION
Minor release that allows linux to make sub second tcp pings:

- Option -w now accepts floats on linux
- When using -w with floats, time between checks is reduced to -w time
- New option -o for statistics
- Minor code cleanup
- Tested against FreeBSD 11 (csh) and CentOS 7/8 (bash)
