### PR TITLE
test fix for busybox issue with -T flag

### DIFF
--- a/tcpping
+++ b/tcpping
@@ -286,11 +286,7 @@ _testSite() {
 	else
 		rtt=`echo "${traceRoute}" | awk '{print $4}'`
 	fi
-	if [ "${traceroute_arg_n}" = true ]; then
-		rtt=`echo "${traceRoute}" | awk '{print $3}'`
-	else
-		rtt=`echo "${traceRoute}" | awk '{print $4}'`
-	fi
+	rtt=`echo "${traceRoute}" | awk '{print $(NF-1)}'`
 	not=`echo "${rtt}" | tr -d ".0123456789"`
 
 	[ "${d}" = "yes" ] && echo "$nowd"


### PR DESCRIPTION
On recent builds of the linuxserver.io smokeping docker image (based on Alpine Linux which ships with BusyBox versions of traceroute), `tcpping` fails when the `-C` flag is used due to improper parsing of `tcptraceroute` output.

This is a small patch that changes the awk method used to grab the output, tested with and without the `-n` flag. It works in both cases (for me).

related: https://github.com/linuxserver/docker-smokeping/issues/197