### PR TITLE
Fix getopts parsing for -6 and -q

### DIFF
--- a/tcpping
+++ b/tcpping
@@ -341,7 +341,7 @@ _quit() {
 		exit
 }
 
-while getopts Zdhzq46:w:cr:nNFSAEi:f:l:m:p:s:x:CM:o opt ; do
+while getopts Zdhzq:46w:cr:nNFSAEi:f:l:m:p:s:x:CM:o opt ; do
 	case "$opt" in
 		d|c|C) eval $opt="yes" ;;
 		q|x) eval $opt="$OPTARG" ;;


### PR DESCRIPTION
**Summary**
Fix `getopts` parsing so `-6` is treated as a flag (not as an option with an argument), and declare that `-q` expects a value per usage.

**Background / Problem**
When using `-6` (Force IPv6), subsequent options are ignored. Example:
```
tcpping -6 -n -C -x 1 api.bilibili.com
```
Expected: `-n`, `-C`, `-x` should apply (fping-style output with `-C`, one sample with `-x 1`).
Actual: `-6` consumes the next flag (e.g., `-n`), option parsing stops early, and output falls back to default traceroute lines.

**Root Cause**
In the `getopts` string, `-6` is mistakenly defined as requiring an argument:
```
getopts Zdhzq46:w:cr:nNFSAEi:f:l:m:p:s:x:CM:o
             ^
```
The `:` after `6` makes `-6` consume the next token.

**Fix**
Remove the `:` after `6`, and add `:` after `q` since `-q` expects a value per usage:
```
getopts Zdhzq:46w:cr:nNFSAEi:f:l:m:p:s:x:CM:o
```

**Testing**
Manually tested:
```
tcpping -6 -n -C -x 1 api.bilibili.com
```
Output format matches `-C` and `-x 1` as expected.

**Note**
This PR description (including the proposed fix) was generated by AI for reference and has been manually tested.